### PR TITLE
Update FOCIL specs

### DIFF
--- a/specs/_features/focil/beacon-chain.md
+++ b/specs/_features/focil/beacon-chain.md
@@ -137,7 +137,7 @@ class NewPayloadRequest(object):
     versioned_hashes: Sequence[VersionedHash]
     parent_beacon_block_root: Root
     execution_requests: ExecutionRequests 
-    il_transactions: List[Transaction, MAX_TRANSACTIONS_PER_INCLUSION_LIST]  # [New in FOCIL]
+    il_transactions: List[Transaction, MAX_TRANSACTIONS_PER_INCLUSION_LIST * IL_COMMITTEE_SIZE]  # [New in FOCIL]
 ```
 
 #### Engine APIs
@@ -151,9 +151,9 @@ def notify_new_payload(self: ExecutionEngine,
                        execution_payload: ExecutionPayload,
                        execution_requests: ExecutionRequests,
                        parent_beacon_block_root: Root,
-                       il_transactions: List[Transaction, MAX_TRANSACTIONS_PER_INCLUSION_LIST] ) -> bool:
+                       il_transactions: List[Transaction, MAX_TRANSACTIONS_PER_INCLUSION_LIST * IL_COMMITTEE_SIZE] ) -> bool:
     """
-    Return ``True`` if and only if ``execution_payload`` and ``execution_requests`` 
+    Return ``True`` if and only if ``execution_payload``, ``execution_requests`` and ``il_transactions``
     are valid with respect to ``self.execution_state``.
     """
     ...

--- a/specs/_features/focil/engine-api.md
+++ b/specs/_features/focil/engine-api.md
@@ -35,6 +35,8 @@ Warning: This file should be placed in https://github.com/ethereum/execution-api
 | - | - |
 | `LOCAL_INCLUSION_LIST_MAX_GAS` |  `uint64(4194304) = 2**22` |
 
+## Structures
+
 ### PayloadStatusV2
 
 This structure contains the result of processing a payload. The fields are encoded as follows:
@@ -47,7 +49,7 @@ This structure contains the result of processing a payload. The fields are encod
 
 ### engine_newPayloadV5
 
-The request of this method is updated with [`ExecutionPayloadV5`](#ExecutionPayloadV5).
+The request of this method is updated with `inclusionListTransactions`.
 
 #### Request
 
@@ -65,7 +67,7 @@ The request of this method is updated with [`ExecutionPayloadV5`](#ExecutionPayl
 #### Specification
 
 1. Client software **MUST** respond to this method call in the following way:
-  * `{status: INVALID_INCLUSION_LIST, latestValidHash: null, validationError: null}` if there are any leftover `inclusionListTransactions` that are not part of the `executionPayload`, they can be processed at the end of the `executionPayload` or the block is full.
+  * `{status: INVALID_INCLUSION_LIST, latestValidHash: null, validationError: null}` if there are any leftover `inclusionListTransactions` that are not part of the `executionPayload`, they can be processed at the end of the `executionPayload` and the block is not full.
 
 ### engine_updateBlockWithInclusionListV1
 

--- a/specs/_features/focil/fork-choice.md
+++ b/specs/_features/focil/fork-choice.md
@@ -87,8 +87,8 @@ def on_inclusion_list(
     ``on_local_inclusion_list`` verify the inclusion list before import it to fork choice store.
     """
     message = signed_inclusion_list.message
-    # Verify inclusion list slot is bouded to the current slot
-    assert get_current_slot(store) != message.slot
+    # Verify inclusion list slot is bounded to the current slot
+    assert get_current_slot(store) == message.slot
 
     state = store.block_states[message.beacon_block_root]
     ilc = get_inclusion_list_committee(state, message.slot)

--- a/specs/_features/focil/p2p-interface.md
+++ b/specs/_features/focil/p2p-interface.md
@@ -32,7 +32,7 @@ The new topics along with the type of the `data` field of a gossipsub message ar
 
 ##### Global topics
 
-FOCIL introduces new global topics for inclusion list.
+FOCIL introduces a new global topic for inclusion list.
 
 ###### `local_inclusion_list`
 
@@ -40,7 +40,7 @@ This topic is used to propagate signed local inclusion list as `SignedLocalInclu
 The following validations MUST pass before forwarding the `local_inclusion_list` on the network, assuming the alias `message = signed_local_inclusion_list.message`:
 
 - _[REJECT]_ The slot `message.slot` is equal to current slot.
-- _[IGNORE]_ The current time is `LOCAL_INCLUSION_CUT_OFF` seconds into the slot.
+- _[IGNORE]_ The current time is before `LOCAL_INCLUSION_LIST_CUT_OFF` seconds into the slot.
 - _[REJECT]_ The transactions `message.transactions` length is within upperbound `MAX_TRANSACTIONS_PER_INCLUSION_LIST`.
 - _[IGNORE]_ The `message` is the first valid message received from the validator with index `message.validate_index` and can be received no more than twice from the same validator index.
 - _[IGNORE]_ The block hash `message.parent_block_hash` is a known execution payload in fork choice.


### PR DESCRIPTION
This PR adds nits and small corrections. Besides, I have one question and one comment:

Question: does a proposer notify EL of all ILs at once by calling `engine_updateInclusionListV1`?

Comment: if `on_inclusion_list` is called every time a validator receives `SignedLocalInclusionList`, it will be tricky to remove a certain `SignedLocalInclusionList` when IL equivocation is spotted.