### PR TITLE
Update `get_proposer_head` for EIP7805

### DIFF
--- a/specs/_features/eip7805/fork-choice.md
+++ b/specs/_features/eip7805/fork-choice.md
@@ -97,6 +97,56 @@ def get_attester_head(store: Store, head_root: Root) -> Root:
 
 ```
 
+##### Modified `get_proposer_head`
+
+The implementation of `get_proposer_head` is modified to also account for `store.unsatisfied_inclusion_list_blocks`.
+
+```python
+def get_proposer_head(store: Store, head_root: Root, slot: Slot) -> Root:
+    head_block = store.blocks[head_root]
+    parent_root = head_block.parent_root
+    parent_block = store.blocks[parent_root]
+
+    # Only re-org the head block if it arrived later than the attestation deadline.
+    head_late = is_head_late(store, head_root)
+
+    # Do not re-org on an epoch boundary where the proposer shuffling could change.
+    shuffling_stable = is_shuffling_stable(slot)
+
+    # Ensure that the FFG information of the new head will be competitive with the current head.
+    ffg_competitive = is_ffg_competitive(store, head_root, parent_root)
+
+    # Do not re-org if the chain is not finalizing with acceptable frequency.
+    finalization_ok = is_finalization_ok(store, slot)
+
+    # Only re-org if we are proposing on-time.
+    proposing_on_time = is_proposing_on_time(store)
+
+    # Only re-org a single slot at most.
+    parent_slot_ok = parent_block.slot + 1 == head_block.slot
+    current_time_ok = head_block.slot + 1 == slot
+    single_slot_reorg = parent_slot_ok and current_time_ok
+
+    # Check that the head has few enough votes to be overpowered by our proposer boost.
+    assert store.proposer_boost_root != head_root  # ensure boost has worn off
+    head_weak = is_head_weak(store, head_root)
+
+    # Check that the missing votes are assigned to the parent and not being hoarded.
+    parent_strong = is_parent_strong(store, parent_root)
+
+
+    reorg_prerequisites = all([shuffling_stable, ffg_competitive, finalization_ok,
+                           proposing_on_time, single_slot_reorg, head_weak, parent_strong])
+    
+    # Check that the head block is in the unsatisfied inclusion list blocks
+    inclusion_list_not_satisfied = head_root in store.unsatisfied_inclusion_list_blocks  # [New in EIP-7805]
+
+    if reorg_prerequisites and (head_late or inclusion_list_not_satisfied):
+        return parent_root
+    else:
+    return head_root
+```
+
 #### New `on_inclusion_list`
 
 `on_inclusion_list` is called to import `signed_inclusion_list` to the fork choice store.


### PR DESCRIPTION
This PR updates `get_proposer_head` for FOCIL to account for block that is `inclusion_list_not_satisfied` and should not be used as parent head